### PR TITLE
fix: query left value in c

### DIFF
--- a/scubatrace/cpp/language.py
+++ b/scubatrace/cpp/language.py
@@ -195,6 +195,12 @@ class C(Language):
                     (#eq? @left "{text}")
                 )
             )
+            (init_declarator
+                (array_declarator
+                    (identifier)@left
+                    (#eq? @left "{text}")
+                )
+            )
             (parameter_declaration
                 declarator: (identifier)@left
                 (#eq? @left "{text}")


### PR DESCRIPTION
to recognize array declarator's identifier as left value in the statement
static PyMethodDef PYXXH64_methods[] = {
    {"update", (PyCFunction)PYXXH64_update, METH_VARARGS, PYXXH64_update_doc},
    {NULL, NULL, 0, NULL}
};